### PR TITLE
Add lazy chunking. And avoid unnecessary cat/chunks

### DIFF
--- a/pytorch_tools/torchfold.py
+++ b/pytorch_tools/torchfold.py
@@ -52,14 +52,17 @@ class Fold(object):
 
         def try_get_batched(self, nodes):
             all_are_nodes = all(isinstance(n, Fold.Node) for n in nodes)
-            if not all_are_nodes:
-                return None
-            same_split_index = len(set(n.split_idx for n in nodes)) == 1
-            same_step = len(set(n.step for n in nodes)) == 1
-            same_op = len(set(n.op for n in nodes)) == 1
-            indices_are_ordered = all(nodes[i].index < nodes[i + 1].index for i in xrange(len(nodes) - 1))
             num_nodes_is_equal = len(nodes) == self.batch_size
-            if not (same_split_index and same_step and same_op and indices_are_ordered and num_nodes_is_equal):
+            if not all_are_nodes or not num_nodes_is_equal:
+                return None
+
+            valid_node_sequence = all(
+                nodes[i].index < nodes[i + 1].index  # Indices are ordered
+                and nodes[i].split_idx == nodes[i + 1].split_idx  # Same split index
+                and nodes[i].step == nodes[i + 1].step  # Same step
+                and nodes[i].op == nodes[i + 1].op  # Same op
+                for i in xrange(len(nodes) - 1))
+            if not valid_node_sequence:
                 return None
 
             if nodes[0].split_idx == -1 and not isinstance(self.result, tuple):

--- a/pytorch_tools/torchfold.py
+++ b/pytorch_tools/torchfold.py
@@ -7,7 +7,6 @@ from torch import optim
 import torch.nn.functional as F
 
 
-
 class Fold(object):
 
     class Node(object):
@@ -33,10 +32,7 @@ class Fold(object):
             return self
 
         def get(self, values):
-            if self.split_idx >= 0:
-                return values[self.step][self.op].get(self.index, self.split_idx)
-            else:
-                return values[self.step][self.op].get(self.index)
+            return values[self.step][self.op].get(self.index, self.split_idx)
 
         def __repr__(self):
             return "[%d:%d]%s" % (

--- a/pytorch_tools/torchfold_test.py
+++ b/pytorch_tools/torchfold_test.py
@@ -38,7 +38,6 @@ class TestEncoder(nn.Module):
 class TorchFoldTest(unittest.TestCase):
 
     def test_rnn(self):
-        return
         f = torchfold.Fold()
         v1, _ = f.add('value2', 1).split(2)
         v2, _ = f.add('value2', 2).split(2)
@@ -52,7 +51,6 @@ class TorchFoldTest(unittest.TestCase):
         self.assertEqual(enc[0].size(), (1, 10))
 
     def test_nobatch(self):
-        return
         f = torchfold.Fold()
         v = []
         for i in range(15):


### PR DESCRIPTION
Slightly improves the performance (~10% speedup) of computations that involve sequential operations of the same kind, e.g. simultaneously computing multiple RNNs on sequences with different lengths.